### PR TITLE
Pretify the logging in logExec to facilitate the debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ function _noop() {}
 
 function _getDummyLogger() {
   const logger = {};
-  _.each(['info', 'error', 'trace', 'warn'], level => logger[level] = _noop);
+  _.each(['info', 'error', 'trace', 'warn',
+  'trace1', 'trace2', 'trace3', 'trace4', 'trace5', 'trace6', 'trace7', 'trace8'], level => logger[level] = _noop);
   return logger;
 }
 
@@ -44,7 +45,7 @@ function _match(text, searchTerm) {
 
 function _objectToNatural(obj) {
   let msg = '';
-  _.each(obj, (v, k) => msg += `${k}=${v}\n`);
+  _.each(obj, (v, k) => msg += `${k}=${v} `);
   return msg;
 }
 
@@ -91,17 +92,20 @@ function logExec(cmd, args, options) {
 
   if (!_.isEmpty(args)) {
     if (_.isArray(args) && args.length > 1) {
-      message += ` with arguments: ${JSON.stringify(args)}`;
+      message += ` ${_.map(args, arg => `"${arg}"`).join(' ')}`;
     } else {
-      message += ` with a single argument: "${_.isArray(args) ? args[0] : args}"`;
+      message += ` "${_.isArray(args) ? args[0] : args}"`;
     }
   }
 
   logger.info(message);
 
-  if (!_.isEmpty(envVars)) logger.trace(`ENVIRONMENT VARIABLES:\n${_objectToNatural(_.omit(envVars, _.isEmpty))}`);
+  if (!_.isEmpty(envVars)) {
+    logger.trace(`ENVIRONMENT VARIABLES:\n${_objectToNatural(_.omitBy(envVars, _.isEmpty))}`);
+  }
 
-  return nos.runProgram(cmd, args, options);
+  // Run the command mutting its output to avoid duplicity
+  return nos.runProgram(cmd, args, _.assign(_.cloneDeep(options), {logger: _getDummyLogger()}));
 }
 
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function _match(text, searchTerm) {
 
 function _objectToNatural(obj) {
   let msg = '';
-  _.each(obj, (v, k) => msg += `${k}=${v} `);
+  _.each(obj, (v, k) => msg += `${k}="${v}" `);
   return msg;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-utils",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Some common node functions",
   "main": "index.js",
   "scripts": {

--- a/test/log-exec.spec.js
+++ b/test/log-exec.spec.js
@@ -42,24 +42,24 @@ describe('#logExec()', () => {
   it('logs provided argument (one)', () => {
     logExec('true', '-l', {logger});
     expect(logger.buffer[0]).to.be
-      .eql({level: 'info', message: 'Executing command: "true" with a single argument: "-l"'});
+      .eql({level: 'info', message: 'Executing command: "true" "-l"'});
   });
 
   it('logs provided arguments (several)', () => {
     logExec('true', ['-l', 'h'], {logger});
     expect(logger.buffer[0]).to.be
-      .eql({level: 'info', message: 'Executing command: "true" with arguments: ["-l","h"]'});
+      .eql({level: 'info', message: 'Executing command: "true" "-l" "h"'});
   });
 
   it('doesn\'t log not provided environment variables', () => {
     logExec('true', {logger});
-    expect(logger.buffer[1].message).to.not.startsWith('ENVIRONMENT VARIABLES');
+    expect(logger.buffer[1]).to.be.empty;
   });
 
   it('logs provided environment variables', () => {
     const env = {var1: 'someContent'};
     logExec('true', {logger, env});
-    expect(logger.buffer[1].message).to.be.eql('ENVIRONMENT VARIABLES:\nvar1=someContent\n');
+    expect(logger.buffer[1].message).to.be.eql('ENVIRONMENT VARIABLES:\nvar1="someContent" ');
   });
 
   it('returns the output of the command', () => {


### PR DESCRIPTION
Before:
```
Executing command: "make" with arguments: ["--jobs=33","install"]
TRACE ENVIRONMENT VARIABLES:
CC=gcc
LD_LIBRARY_PATH=/opt/bitnami/php/lib:/opt/bitnami/common/lib
DYLD_LIBRARY_PATH=
PATH=/opt/bitnami/php/bin:/opt/bitnami/common/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bitnami/nami/bin
CFLAGS=-m64 -fPIC -s
CPPFLAGS=-I/opt/bitnami/php/include -I/opt/bitnami/common/include
LDFLAGS=-Wl,-rpath=/opt/bitnami/php/lib -L/opt/bitnami/php/lib -Wl,-rpath=/opt/bitnami/common/lib -L/opt/bitnami/common/lib
[runProgram] Executing: make --jobs=33,install
```

Now users can copy an paste the commands (and we avoid duplicated output):

```
Executing command: "make" "--jobs=33" "install"
TRACE ENVIRONMENT VARIABLES:
CC="gcc" LD_LIBRARY_PATH="/opt/bitnami/common/lib" PATH="/opt/bitnami/common/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bitnami/nami/bin" CFLAGS="-m64 -fPIC -s" CPPFLAGS="-I/opt/bitnami/common/include" LDFLAGS="-Wl,-rpath=/opt/bitnami/common/lib -L/opt/bitnami/common/lib"
```